### PR TITLE
Change types for some File properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Changelog
 
+### [0.6.2](https://kaos.sh/pachca/0.6.2)
+
+- Type of `File.Size` changed from `uint` to `int64`
+- Type of `File.Width` changed from `uint` to `int`
+- Type of `File.Height` changed from `uint` to `int`
+
+### [0.6.1](https://kaos.sh/pachca/0.6.1)
+
+- Updated compatibility with the latest version of API
+- Dependencies update
+
 ### [0.6.0](https://kaos.sh/pachca/0.6.0)
 
 - `AddThreadMessage` and `AddThreadMessageText` now also returns `Thread`

--- a/pachca.go
+++ b/pachca.go
@@ -252,9 +252,9 @@ type File struct {
 	Name   string   `json:"name"`
 	Type   FileType `json:"file_type,omitempty"`
 	URL    string   `json:"url,omitempty"`
-	Size   uint     `json:"size"`
-	Width  uint     `json:"width,omitzero"`
-	Height uint     `json:"height,omitzero"`
+	Size   int64    `json:"size"`
+	Width  int      `json:"width,omitzero"`
+	Height int      `json:"height,omitzero"`
 }
 
 // Files is a slice of attachments
@@ -339,7 +339,7 @@ type UnfurlLink struct {
 type uploadInfo struct {
 	Key         string        // Uploading key
 	Name        string        // File name
-	Size        uint          // File size
+	Size        int64         // File size
 	ContentType string        // Content type
 	Buffer      *bytes.Buffer // Buffer with data
 }
@@ -2550,7 +2550,7 @@ func createMultipartData(file string, upload *Upload, maxFileSize int64) (*uploa
 	info := &uploadInfo{
 		Key:  strings.ReplaceAll(upload.Key, "${filename}", fileName),
 		Name: fileName,
-		Size: uint(stat.Size()),
+		Size: stat.Size(),
 	}
 
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
#### Improvements
- Type of `File.Size` changed from `uint` to `int64`
- Type of `File.Width` changed from `uint` to `int`
- Type of `File.Height` changed from `uint` to `int`
